### PR TITLE
KEY-2 Navigate between highlights

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,3 +1,10 @@
+const utilsModule = (function () {
+  return {
+    first: array => array[0],
+    last: array => array[array.length - 1]
+  };
+})();
+
 const navigatorModule = (function () {
   function getCentralHighlight(highlights, pageCentralPoint) {
     const highlightsSortedByDistanceFromCenter = mapHighlightsWithDistanceFromPoint(highlights, pageCentralPoint)
@@ -28,11 +35,12 @@ const navigatorModule = (function () {
       verticalDistances.filter(({ distance }) => distance < 0)
     ].map(nearestHighlights => nearestHighlights.map(({ highlight }) => highlight));
 
+    const { first, last } = utilsModule;
     return {
-      down: downNearest[0],
-      left: leftNearest[leftNearest.length - 1],
-      right: rightNearest[0],
-      up: upNearest[upNearest.length - 1]
+      down: first(downNearest),
+      left: last(leftNearest),
+      right: first(rightNearest),
+      up: last(upNearest)
     };
   }
 
@@ -209,3 +217,5 @@ const appModule = (function () {
 })();
 
 appModule.start(window);
+
+// filter very small highlights

--- a/contentScript.js
+++ b/contentScript.js
@@ -230,7 +230,7 @@ const appModule = (function () {
   }
 
   function simulateClick() {
-    const elementToClick = self.selectedHighlight.clickable;
+    const elementToClick = self.selectedHighlight?.clickable;
     if (elementToClick) {
       elementToClick.click();
       hideHighlights();

--- a/contentScript.js
+++ b/contentScript.js
@@ -81,6 +81,10 @@ const highlightsModule = (function () {
     const domDocument = domWindow.document;
     self.highlights = domHighlightModule.createHighlightsOnPage(domDocument);
     self.highlights.forEach(highlight => domDocument.body.appendChild(highlight));
+
+    const centralPoint = { x: domWindow.innerWidth/2, y: domWindow.innerHeight/2 };
+    const centralHighlight = navigatorModule.getCentralHighlight(self.highlights, centralPoint);
+    domHighlightModule.selectHighlight(centralHighlight);
   }
 
   function hide() {

--- a/contentScript.js
+++ b/contentScript.js
@@ -7,7 +7,8 @@ const utilsModule = (function () {
 
 const navigatorModule = (function () {
   function getCentralHighlight(highlights, pageCentralPoint) {
-    const highlightsSortedByDistanceFromCenter = mapHighlightsWithDistanceFromPoint(highlights, pageCentralPoint)
+    const highlightsSortedByDistanceFromCenter = highlights
+      .map(assignDistanceFromPoint.bind(null, pageCentralPoint))
       .sort((highlight1, highlight2) => highlight1.distance - highlight2.distance);
 
     return highlightsSortedByDistanceFromCenter[0];
@@ -15,13 +16,13 @@ const navigatorModule = (function () {
 
   function getNearestHighlights(highlights, selectedHighlight) {
     const selectedHighlightCentralPoint = getCentralPoint(selectedHighlight.rect);
-    const highlightsWithPositionData = mapHighlightsWithCentralPointData(highlights);
+    const highlightsWithCentralPoints = highlights.map(assignCentralPoint);
 
-    const verticalDistances = highlightsWithPositionData
+    const verticalDistances = highlightsWithCentralPoints
       .filter(({ rect }) => rectsVerticallyAligned(selectedHighlight.rect, rect))
       .map(data => ({ ...data, distance: data.centralPoint.y - selectedHighlightCentralPoint.y }))
       .sort((highlight1, highlight2) => highlight1.distance - highlight2.distance);
-    const horizontalDistances = highlightsWithPositionData
+    const horizontalDistances = highlightsWithCentralPoints
       .filter(({ rect }) => rectsHorizontallyAligned(selectedHighlight.rect, rect))
       .map(data => ({ ...data, distance: data.centralPoint.x - selectedHighlightCentralPoint.x }))
       .sort((highlight1, highlight2) => highlight1.distance - highlight2.distance);
@@ -42,20 +43,19 @@ const navigatorModule = (function () {
     };
   }
 
-  function mapHighlightsWithDistanceFromPoint(highlights, point) {
-    return mapHighlightsWithCentralPointData(highlights)
-      .map(data => ({
-        ...data,
-        distance: getCartesianDistance(data.centralPoint, point)
-      }));
+  function assignDistanceFromPoint(point, highlight) {
+    const highlightWithCentralPoint = assignCentralPoint(highlight);
+    return {
+      ...highlightWithCentralPoint,
+      distance: getCartesianDistance(highlightWithCentralPoint.centralPoint, point)
+    };
   }
 
-  function mapHighlightsWithCentralPointData(highlights) {
-    return highlights
-      .map(highlight => ({
-        ...highlight,
-        centralPoint: getCentralPoint(highlight.rect)
-      }));
+  function assignCentralPoint(highlight) {
+    return {
+      ...highlight,
+      centralPoint: getCentralPoint(highlight.rect)
+    };
   }
 
   function rectsVerticallyAligned(rect1, rect2) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -214,9 +214,11 @@ const appModule = (function () {
   }
 
   function navigateHighlights(event, direction) {
-    const nearestHighlights = navigatorModule.getNearestHighlights(self.highlights, self.selectedHighlight);
-    navigateHighlightTo(nearestHighlights[direction]);
-    event.preventDefault();
+    if (self.highlightsVisible) {
+      const nearestHighlights = navigatorModule.getNearestHighlights(self.highlights, self.selectedHighlight);
+      navigateHighlightTo(nearestHighlights[direction]);
+      event.preventDefault();
+    }
   }
 
   function navigateHighlightTo(nearestHighlight) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -67,42 +67,57 @@ const domHighlightModule = (function () {
 })();
 
 const highlightsModule = (function () {
+  function show(highlights, domWindow) {
+    const domDocument = domWindow.document;
+    highlights.forEach(highlight => domDocument.body.appendChild(highlight));
+
+    const centralPoint = { x: domWindow.innerWidth/2, y: domWindow.innerHeight/2 };
+    const centralHighlight = navigatorModule.getCentralHighlight(highlights, centralPoint);
+    domHighlightModule.selectHighlight(centralHighlight);
+  }
+
+  function hide(highlights) {
+    highlights.forEach(highlight => highlight.remove());
+  }
+
+  return {
+    hide,
+    show
+  };
+})();
+
+const appModule = (function () {
   const self = {
     highlights: [],
     highlightsVisible: false
   };
 
+  function start(domWindow) {
+    addKeydownListener(domWindow, "f", toggleHighlights.bind(null, domWindow));
+  }
+
   function toggleHighlights(domWindow) {
-    self.highlightsVisible ? hide() : show(domWindow);
     self.highlightsVisible = !self.highlightsVisible;
-  }
-
-  function show(domWindow) {
-    const domDocument = domWindow.document;
-    self.highlights = domHighlightModule.createHighlightsOnPage(domDocument);
-    self.highlights.forEach(highlight => domDocument.body.appendChild(highlight));
-
-    const centralPoint = { x: domWindow.innerWidth/2, y: domWindow.innerHeight/2 };
-    const centralHighlight = navigatorModule.getCentralHighlight(self.highlights, centralPoint);
-    domHighlightModule.selectHighlight(centralHighlight);
-  }
-
-  function hide() {
-    self.highlights.forEach(highlight => highlight.remove());
-    self.highlights = [];
+    if (self.highlightsVisible) {
+      self.highlights = domHighlightModule.createHighlightsOnPage(domWindow.document);
+      highlightsModule.show(self.highlights, domWindow);
+    } else {
+      highlightsModule.hide(self.highlights);
+      self.highlights = [];
+    }
   }
 
   return {
-    toggleHighlights
+    start
   };
 })();
 
-function bindToggleHighlightsOnKeydown(domWindow, key) {
+function addKeydownListener(domWindow, key, handler) {
   domWindow.document.addEventListener("keydown", (event) => {
-    switch (event.key) {
-      case key: highlightsModule.toggleHighlights(window);
+    if (event.key === key) {
+      handler();
     }
   });
 }
 
-bindToggleHighlightsOnKeydown(window, "f");
+appModule.start(window);

--- a/contentScript.js
+++ b/contentScript.js
@@ -11,7 +11,8 @@ const navigatorModule = (function () {
       .map(assignDistanceFromPoint.bind(null, pageCentralPoint))
       .sort((highlight1, highlight2) => highlight1.distance - highlight2.distance);
 
-    return highlightsSortedByDistanceFromCenter[0];
+    const { first } = utilsModule;
+    return first(highlightsSortedByDistanceFromCenter);
   }
 
   function getNearestHighlights(highlights, selectedHighlight) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,3 +1,32 @@
+const navigatorModule = (function () {
+  function getCentralHighlight(highlights, pageCentralPoint) {
+    const highlightsSortedByDistanceFromCenter = highlights
+      .map(highlight => [highlight, getCentralPoint(highlight)])
+      .map(([highlight, highlightCentralPoint]) => ({
+        highlight,
+        distanceFromCenter: getCartesianDistance(highlightCentralPoint, pageCentralPoint)
+      }))
+      .sort((highlight1, highlight2) => highlight1.distanceFromCenter - highlight2.distanceFromCenter);
+
+    return highlightsSortedByDistanceFromCenter.length > 0
+      ? highlightsSortedByDistanceFromCenter[0].highlight
+      : null;
+  }
+
+  function getCentralPoint(highlight) {
+    const rect = highlight.getBoundingClientRect();
+    return { x: rect.x + .5*rect.width, y: rect.y + .5*rect.height };
+  }
+
+  function getCartesianDistance(point1, point2) {
+    return Math.sqrt((point1.x - point2.x)**2 + (point1.y - point2.y)**2);
+  }
+
+  return {
+    getCentralHighlight
+  };
+})();
+
 const domHighlightModule = (function () {
   function createHighlightsOnPage(domDocument) {
     return queryClickableAll(domDocument).map(createHighlightFromClickable.bind(null, domDocument));

--- a/contentScript.js
+++ b/contentScript.js
@@ -110,6 +110,19 @@ const domHighlightModule = (function () {
     });
   }
 
+  function showHighlights(highlights, domWindow) {
+    const domDocument = domWindow.document;
+    highlights
+      .map(highlight => highlight.element)
+      .forEach(highlight => domDocument.body.appendChild(highlight));
+  }
+
+  function hideHighlights(highlights) {
+    highlights
+      .map(highlight => highlight.element)
+      .forEach(highlight => highlight.remove());
+  }
+
   function queryClickableAll(domDocument) {
     const clickableSelector = "a, button, input[type=\"button\"], input[type=\"submit\"], input[type=\"reset\"]";
     return Array.from(domDocument.querySelectorAll(clickableSelector));
@@ -147,29 +160,11 @@ const domHighlightModule = (function () {
 
   return {
     createHighlightsOnPage,
+    hideHighlights,
     selectHighlight,
+    showHighlights,
     unselectHighlight
   }
-})();
-
-const highlightsModule = (function () {
-  function show(highlights, domWindow) {
-    const domDocument = domWindow.document;
-    highlights
-      .map(highlight => highlight.element)
-      .forEach(highlight => domDocument.body.appendChild(highlight));
-  }
-
-  function hide(highlights) {
-    highlights
-      .map(highlight => highlight.element)
-      .forEach(highlight => highlight.remove());
-  }
-
-  return {
-    hide,
-    show
-  };
 })();
 
 const appModule = (function () {
@@ -201,13 +196,13 @@ const appModule = (function () {
       self.highlightsVisible = !self.highlightsVisible;
       if (self.highlightsVisible) {
         self.highlights = domHighlightModule.createHighlightsOnPage(domWindow.document);
-        highlightsModule.show(self.highlights, domWindow);
+        domHighlightModule.showHighlights(self.highlights, domWindow);
 
         const centralPoint = { x: domWindow.innerWidth/2, y: domWindow.innerHeight/2 };
         self.selectedHighlight = navigatorModule.getCentralHighlight(self.highlights, centralPoint);
         domHighlightModule.selectHighlight(self.selectedHighlight);
       } else {
-        highlightsModule.hide(self.highlights);
+        domHighlightModule.hideHighlights(self.highlights);
         self.highlights = [];
         self.selectedHighlight = null;
       }

--- a/contentScript.js
+++ b/contentScript.js
@@ -32,6 +32,13 @@ const domHighlightModule = (function () {
     return queryClickableAll(domDocument).map(createHighlightFromClickable.bind(null, domDocument));
   }
 
+  function selectHighlight(highlight) {
+    Object.assign(highlight.style, {
+      background: "yellow",
+      opacity: .5
+    });
+  }
+
   function queryClickableAll(domDocument) {
     const clickableSelector = "a, button, input[type=\"button\"], input[type=\"submit\"], input[type=\"reset\"]";
     return Array.from(domDocument.querySelectorAll(clickableSelector));
@@ -54,7 +61,8 @@ const domHighlightModule = (function () {
   }
 
   return {
-    createHighlightsOnPage
+    createHighlightsOnPage,
+    selectHighlight
   }
 })();
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -171,7 +171,6 @@ const appModule = (function () {
   const self = {
     highlights: [],
     highlightsVisible: false,
-    focusedInputs: new Set(),
     selectedHighlight: null
   };
 
@@ -187,26 +186,31 @@ const appModule = (function () {
         case "ArrowDown": navigateHighlights(event, "down"); break;
         case "ArrowLeft": navigateHighlights(event, "left"); break;
         case "ArrowRight": navigateHighlights(event, "right"); break;
+        case "Enter": simulateClick(); break;
       }
     });
   }
 
   function toggleHighlights(domWindow) {
-    if (self.focusedInputs.size === 0) {
-      self.highlightsVisible = !self.highlightsVisible;
-      if (self.highlightsVisible) {
-        self.highlights = domHighlightModule.createHighlightsOnPage(domWindow.document);
-        domHighlightModule.showHighlights(self.highlights, domWindow);
+    self.highlightsVisible ? hideHighlights() : showHighlights(domWindow);
+  }
 
-        const centralPoint = { x: domWindow.innerWidth/2, y: domWindow.innerHeight/2 };
-        self.selectedHighlight = navigatorModule.getCentralHighlight(self.highlights, centralPoint);
-        domHighlightModule.selectHighlight(self.selectedHighlight);
-      } else {
-        domHighlightModule.hideHighlights(self.highlights);
-        self.highlights = [];
-        self.selectedHighlight = null;
-      }
-    }
+  function showHighlights(domWindow) {
+    self.highlights = domHighlightModule.createHighlightsOnPage(domWindow.document);
+    domHighlightModule.showHighlights(self.highlights, domWindow);
+
+    const centralPoint = { x: domWindow.innerWidth/2, y: domWindow.innerHeight/2 };
+    self.selectedHighlight = navigatorModule.getCentralHighlight(self.highlights, centralPoint);
+    domHighlightModule.selectHighlight(self.selectedHighlight);
+
+    self.highlightsVisible = true;
+  }
+
+  function hideHighlights() {
+    domHighlightModule.hideHighlights(self.highlights);
+    self.highlights = [];
+    self.selectedHighlight = null;
+    self.highlightsVisible = false;
   }
 
   function navigateHighlights(event, direction) {
@@ -220,6 +224,14 @@ const appModule = (function () {
       domHighlightModule.unselectHighlight(self.selectedHighlight)
       self.selectedHighlight = nearestHighlight;
       domHighlightModule.selectHighlight(self.selectedHighlight);
+    }
+  }
+
+  function simulateClick() {
+    const elementToClick = self.selectedHighlight.clickable;
+    if (elementToClick) {
+      elementToClick.click();
+      hideHighlights();
     }
   }
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -233,5 +233,3 @@ const appModule = (function () {
 })();
 
 appModule.start(window);
-
-// filter very small highlights

--- a/contentScript.js
+++ b/contentScript.js
@@ -128,7 +128,7 @@ const domHighlightModule = (function () {
     return Array.from(domDocument.querySelectorAll(clickableSelector));
   }
 
-  function createHighlightFromClickable(domDocument, { rect }) {
+  function createHighlightFromClickable(domDocument, { clickable, rect }) {
     const element = domDocument.createElement("div");
     Object.assign(element.style, {
       background: "transparent",
@@ -140,12 +140,12 @@ const domHighlightModule = (function () {
       width: rect.width + "px",
       zIndex: 999999999
     });
-    return { element, rect };
+    return { clickable, element, rect };
   }
 
   function assignBoundingClientRect(clickableElement) {
     return {
-      clickableElement,
+      clickable: clickableElement,
       rect: clickableElement.getBoundingClientRect()
     };
   }

--- a/contentScript.js
+++ b/contentScript.js
@@ -97,8 +97,12 @@ const highlightsModule = (function () {
   };
 })();
 
-window.document.addEventListener("keydown", (event) => {
-  switch (event.key) {
-    case "f": highlightsModule.toggleHighlights(window);
-  }
-});
+function bindToggleHighlightsOnKeydown(domWindow, key) {
+  domWindow.document.addEventListener("keydown", (event) => {
+    switch (event.key) {
+      case key: highlightsModule.toggleHighlights(window);
+    }
+  });
+}
+
+bindToggleHighlightsOnKeydown(window, "f");

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,15 +1,14 @@
-const highlightsModuleFactory = function (domDocument) {
-  const self = {
-    highlights: queryClickableAll().map(createHighlightFromClickable),
-    highlightsVisible: false
-  };
+const domHighlightModule = (function () {
+  function createHighlightsOnPage(domDocument) {
+    return queryClickableAll(domDocument).map(createHighlightFromClickable.bind(null, domDocument));
+  }
 
-  function queryClickableAll() {
+  function queryClickableAll(domDocument) {
     const clickableSelector = "a, button, input[type=\"button\"], input[type=\"submit\"], input[type=\"reset\"]";
     return Array.from(domDocument.querySelectorAll(clickableSelector));
   }
 
-  function createHighlightFromClickable(clickableElement) {
+  function createHighlightFromClickable(domDocument, clickableElement) {
     const elementPosition = clickableElement.getBoundingClientRect();
     const highlight = domDocument.createElement("div");
     Object.assign(highlight.style, {
@@ -25,28 +24,40 @@ const highlightsModuleFactory = function (domDocument) {
     return highlight;
   }
 
-  function toggleHighlights() {
-    self.highlightsVisible ? hide(self.highlights) : show(self.highlights);
+  return {
+    createHighlightsOnPage
+  }
+})();
+
+const highlightsModule = (function () {
+  const self = {
+    highlights: [],
+    highlightsVisible: false
+  };
+
+  function toggleHighlights(domWindow) {
+    self.highlightsVisible ? hide() : show(domWindow);
     self.highlightsVisible = !self.highlightsVisible;
   }
 
-  function show(highlights) {
-    highlights.forEach(highlight => domDocument.body.appendChild(highlight));
+  function show(domWindow) {
+    const domDocument = domWindow.document;
+    self.highlights = domHighlightModule.createHighlightsOnPage(domDocument);
+    self.highlights.forEach(highlight => domDocument.body.appendChild(highlight));
   }
 
-  function hide(highlights) {
-    highlights.forEach(highlight => highlight.remove());
+  function hide() {
+    self.highlights.forEach(highlight => highlight.remove());
+    self.highlights = [];
   }
 
   return {
     toggleHighlights
   };
-};
-
-const highlightsModule = highlightsModuleFactory(window.document);
+})();
 
 window.document.addEventListener("keydown", (event) => {
   switch (event.key) {
-    case "f": highlightsModule.toggleHighlights();
+    case "f": highlightsModule.toggleHighlights(window);
   }
 });


### PR DESCRIPTION
For end user:
* navigating between highlights using arrow keys
* possibility to simulate 'click' event on given element by pressing Enter when proper highlight is selected

Technical summary:
* remove highlightsModule, now showing/hiding highlights is the responsibility of domHighlightModule (it's the only one making operations on DOM)
* create appModule, encapsulating all state and high-level operations, like 'toggleHighlights', 'navigateHighlights' and 'simulateClick'
* created utilsModule with some very basic util functions
* assign additional data to highlight objects: bounding client rect, original clickable element and the actual highlight element itself