### PR TITLE
[KEY-3] Treat <input>s as clickable elements

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -195,6 +195,7 @@ const appModule = (function () {
         case "ArrowLeft": navigateHighlights(event, "left"); break;
         case "ArrowRight": navigateHighlights(event, "right"); break;
         case "Enter": simulateClick(event); break;
+        case "Escape": hideHighlights(); break;
       }
     });
   }

--- a/contentScript.js
+++ b/contentScript.js
@@ -123,8 +123,15 @@ const domHighlightModule = (function () {
       .forEach(highlight => highlight.remove());
   }
 
+  function simulateUserClickOnElement(element) {
+    const elementIsInput = element.matches("input");
+    const elementIsOfTypeButton = ["button", "reset", "submit"].includes(element.type);
+    const shouldBeFocused = elementIsInput && !elementIsOfTypeButton;
+    shouldBeFocused ? element.focus() : element.click();
+  }
+
   function queryClickableAll(domDocument) {
-    const clickableSelector = "a, button, input[type=\"button\"], input[type=\"submit\"], input[type=\"reset\"]";
+    const clickableSelector = "a, button, input";
     return Array.from(domDocument.querySelectorAll(clickableSelector));
   }
 
@@ -163,6 +170,7 @@ const domHighlightModule = (function () {
     hideHighlights,
     selectHighlight,
     showHighlights,
+    simulateUserClickOnElement,
     unselectHighlight
   }
 })();
@@ -230,9 +238,9 @@ const appModule = (function () {
   }
 
   function simulateClick() {
-    const elementToClick = self.selectedHighlight?.clickable;
-    if (elementToClick) {
-      elementToClick.click();
+    const element = self.selectedHighlight?.clickable;
+    if (element) {
+      domHighlightModule.simulateUserClickOnElement(element);
       hideHighlights();
     }
   }

--- a/contentScript.js
+++ b/contentScript.js
@@ -124,9 +124,13 @@ const domHighlightModule = (function () {
   }
 
   function simulateUserClickOnElement(element) {
-    const elementNeedsFocus = element.matches("input, select, textarea");
-    const elementIsOfTypeButton = ["button", "reset", "submit"].includes(element.type);
-    const shouldBeFocused = elementNeedsFocus && !elementIsOfTypeButton;
+    const tagsNeedingFocus = ["select", "textarea"];
+    const tagsNeedingFocusSelector = tagsNeedingFocus.join(",");
+
+    const inputTypesNeedingClick = ["button", "checkbox", "file", "image", "radio", "reset", "submit"];
+    const inputNeedingClickSelector = inputTypesNeedingClick.map(type => `input[type="${type}"]`).join(",");
+
+    const shouldBeFocused = element.matches(tagsNeedingFocusSelector) && !element.matches(inputNeedingClickSelector);
     shouldBeFocused ? element.focus() : element.click();
   }
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -131,7 +131,7 @@ const domHighlightModule = (function () {
   }
 
   function queryClickableAll(domDocument) {
-    const clickableSelector = "a, button, input";
+    const clickableSelector = "a, button, input, textarea";
     return Array.from(domDocument.querySelectorAll(clickableSelector));
   }
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -194,7 +194,7 @@ const appModule = (function () {
         case "ArrowDown": navigateHighlights(event, "down"); break;
         case "ArrowLeft": navigateHighlights(event, "left"); break;
         case "ArrowRight": navigateHighlights(event, "right"); break;
-        case "Enter": simulateClick(); break;
+        case "Enter": simulateClick(event); break;
       }
     });
   }
@@ -237,10 +237,11 @@ const appModule = (function () {
     }
   }
 
-  function simulateClick() {
+  function simulateClick(event) {
     const element = self.selectedHighlight?.clickable;
     if (element) {
       domHighlightModule.simulateUserClickOnElement(element);
+      event.preventDefault();
       hideHighlights();
     }
   }

--- a/contentScript.js
+++ b/contentScript.js
@@ -124,14 +124,14 @@ const domHighlightModule = (function () {
   }
 
   function simulateUserClickOnElement(element) {
-    const elementIsInput = element.matches("input");
+    const elementNeedsFocus = element.matches("input, select, textarea");
     const elementIsOfTypeButton = ["button", "reset", "submit"].includes(element.type);
-    const shouldBeFocused = elementIsInput && !elementIsOfTypeButton;
+    const shouldBeFocused = elementNeedsFocus && !elementIsOfTypeButton;
     shouldBeFocused ? element.focus() : element.click();
   }
 
   function queryClickableAll(domDocument) {
-    const clickableSelector = "a, button, input, textarea";
+    const clickableSelector = "a, button, input, select, textarea";
     return Array.from(domDocument.querySelectorAll(clickableSelector));
   }
 


### PR DESCRIPTION
* `<input>`s are highlighted
* `<input>`s can be clicked or focused, based on the "type" attribute of particular <input> element
* `Escape` key press removes highlights and focused elements