### PR TITLE
[KEY-7] Don't show highlights when user is typing some text

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -33,7 +33,7 @@ function listenKeydownEvents(domWindow: Window) {
       case "ArrowLeft": navigateHighlights(event, "left"); break;
       case "ArrowRight": navigateHighlights(event, "right"); break;
       case "Enter": simulateClick(event); break;
-      case "Escape": {
+      default: {
         hideHighlights();
         blurFocusedElement();
         break;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,21 @@
 export const Utils = {
   Array: {
     first
+  },
+  Function: {
+    composeLeft,
+    composeRight
   }
 };
+
+function composeRight(...functions: Function[]): Function {
+  const reversedFunctions = functions.slice().reverse();
+  return composeLeft(...reversedFunctions);
+}
+
+function composeLeft(...functions: Function[]): Function {
+  return functions.reduce((acc, func) => (...args) => func(acc(...args)), value => value);
+}
 
 function first<T>(array: T[]): T {
   return array[0];


### PR DESCRIPTION
* every non-handled keydown event hides highlights (not only "Escape")
* typing some text (sequence of keydown events pressed when highlights are not shown, each after no longer than 1000 ms after previous) blocks the extension